### PR TITLE
fix typo in documentation

### DIFF
--- a/book/07-git-tools/sections/submodules.asc
+++ b/book/07-git-tools/sections/submodules.asc
@@ -181,7 +181,7 @@ Submodule path 'DbConnector': checked out 'c3f01dc8862123d317dd46284b05b6892c7b2
 Nu is je `DbConnector` subdirectory in precies dezelfde staat als het was toen je het eerder committe.
 
 Er is echter een andere, iets eenvoudiger, manier om dit te doen.
-Als je `--recursive-submodules` doorgeeft aan het `git clone` commando zal het automatisch elke submodule in de repository initialiseren en updaten.
+Als je `--recurse-submodules` doorgeeft aan het `git clone` commando zal het automatisch elke submodule in de repository initialiseren en updaten.
 
 [source,console]
 ----


### PR DESCRIPTION
--recursive-submodules is a faulty option where the working option is --recurse-submodules